### PR TITLE
feat: ArgoCD GitOps 환경 구성 (closes #1)

### DIFF
--- a/eks/README.md
+++ b/eks/README.md
@@ -1,0 +1,105 @@
+# eks/ — GitOps 매니페스트 (ArgoCD)
+
+ArgoCD App of Apps 패턴으로 관리되는 Kubernetes 매니페스트 디렉토리입니다.
+kind(로컬)와 EKS(실전) 환경을 Kustomize overlays로 분기합니다.
+
+---
+
+## 디렉토리 구조
+
+```
+eks/
+├── apps/                              # ArgoCD Application CRD (App of Apps)
+│   ├── root.yaml                      # 루트 앱 — eks/apps/ 를 감시하며 하위 앱 자동 등록
+│   ├── backend.yaml
+│   ├── ai.yaml
+│   ├── postgres.yaml
+│   └── redis.yaml
+└── manifests/
+    ├── base/                          # 환경 공통 매니페스트
+    │   ├── backend/                   # deployment, service, rbac
+    │   ├── ai/                        # deployment, service
+    │   ├── postgres/                  # deployment, service
+    │   └── redis/                     # deployment, service
+    └── overlays/
+        ├── kind/                      # 로컬 kind 전용
+        │   ├── backend/               # imagePullPolicy: Never 패치
+        │   ├── ai/                    # imagePullPolicy: Never 패치
+        │   ├── postgres/              # 패치 없음 (base 그대로)
+        │   └── redis/                 # 패치 없음 (base 그대로)
+        └── eks/                       # AWS EKS 전용
+            ├── backend/               # imagePullPolicy: Always 패치
+            ├── ai/                    # imagePullPolicy: Always 패치
+            ├── postgres/
+            └── redis/
+```
+
+---
+
+## ArgoCD 설치 및 연결 (kind 기준)
+
+### 1. 클러스터 생성
+
+```powershell
+kind create cluster --config kind/cluster.yaml
+```
+
+### 2. ArgoCD 설치
+
+```powershell
+kubectl create namespace argocd
+kubectl apply -n argocd -f https://raw.githubusercontent.com/argoproj/argo-cd/stable/manifests/install.yaml
+
+# 모든 Pod가 Running 될 때까지 대기
+kubectl get pods -n argocd -w
+```
+
+### 3. ArgoCD UI 접속
+
+```powershell
+kubectl port-forward svc/argocd-server -n argocd 8080:443
+```
+
+브라우저: `https://localhost:8080`
+
+초기 비밀번호 확인:
+```powershell
+kubectl get secret argocd-initial-admin-secret -n argocd -o jsonpath="{.data.password}" | base64 -d
+```
+
+ID: `admin` / PW: 위 명령 결과
+
+### 4. 루트 앱 등록 (App of Apps 시작)
+
+```powershell
+kubectl apply -f eks/apps/root.yaml
+```
+
+이 한 줄로 ArgoCD가 `eks/apps/` 디렉토리를 감시하기 시작하고,
+`backend`, `ai`, `postgres`, `redis` Application이 자동으로 등록됩니다.
+
+---
+
+## GitOps 흐름
+
+```
+Git push → ArgoCD 감지 (기본 3분 폴링) → 자동 sync → 클러스터 반영
+```
+
+매니페스트를 수정하고 `main` 브랜치에 push하면 ArgoCD가 자동으로 클러스터에 적용합니다.
+
+---
+
+## EKS 전환 방법
+
+`eks/apps/` 아래 각 Application의 `path`를 변경하기만 하면 됩니다.
+
+```yaml
+# 변경 전 (kind)
+path: eks/manifests/overlays/kind/backend
+
+# 변경 후 (EKS)
+path: eks/manifests/overlays/eks/backend
+```
+
+변경 후 `main`에 push → ArgoCD 자동 반영.

--- a/eks/apps/ai.yaml
+++ b/eks/apps/ai.yaml
@@ -1,0 +1,20 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: ai
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/DGU-CAP/infra.git
+    targetRevision: HEAD
+    path: eks/manifests/overlays/kind/ai  # EKS 전환 시 overlays/eks/ai 로 변경
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: default
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true

--- a/eks/apps/backend.yaml
+++ b/eks/apps/backend.yaml
@@ -1,0 +1,20 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: backend
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/DGU-CAP/infra.git
+    targetRevision: HEAD
+    path: eks/manifests/overlays/kind/backend  # EKS 전환 시 overlays/eks/backend 로 변경
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: default
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true

--- a/eks/apps/postgres.yaml
+++ b/eks/apps/postgres.yaml
@@ -1,0 +1,20 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: postgres
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/DGU-CAP/infra.git
+    targetRevision: HEAD
+    path: eks/manifests/overlays/kind/postgres  # EKS 전환 시 overlays/eks/postgres 로 변경
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: default
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true

--- a/eks/apps/redis.yaml
+++ b/eks/apps/redis.yaml
@@ -1,0 +1,20 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: redis
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/DGU-CAP/infra.git
+    targetRevision: HEAD
+    path: eks/manifests/overlays/kind/redis  # EKS 전환 시 overlays/eks/redis 로 변경
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: default
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true

--- a/eks/apps/root.yaml
+++ b/eks/apps/root.yaml
@@ -1,0 +1,20 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: root
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/DGU-CAP/infra.git
+    targetRevision: HEAD
+    path: eks/apps
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: argocd
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true

--- a/eks/manifests/base/ai/deployment.yaml
+++ b/eks/manifests/base/ai/deployment.yaml
@@ -1,0 +1,19 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ai
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: ai
+  template:
+    metadata:
+      labels:
+        app: ai
+    spec:
+      containers:
+        - name: ai
+          image: 428185450315.dkr.ecr.ap-northeast-2.amazonaws.com/dgu-cap-ai:latest
+          ports:
+            - containerPort: 8000

--- a/eks/manifests/base/ai/kustomization.yaml
+++ b/eks/manifests/base/ai/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - deployment.yaml
+  - service.yaml

--- a/eks/manifests/base/ai/service.yaml
+++ b/eks/manifests/base/ai/service.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: ai
+spec:
+  selector:
+    app: ai
+  ports:
+    - port: 8000
+      targetPort: 8000
+  type: ClusterIP

--- a/eks/manifests/base/backend/deployment.yaml
+++ b/eks/manifests/base/backend/deployment.yaml
@@ -1,0 +1,37 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: backend
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: backend
+  template:
+    metadata:
+      labels:
+        app: backend
+    spec:
+      serviceAccountName: backend
+      containers:
+        - name: backend
+          image: 428185450315.dkr.ecr.ap-northeast-2.amazonaws.com/dgu-cap-backend:latest
+          ports:
+            - containerPort: 8080
+          env:
+            - name: SPRING_DATASOURCE_URL
+              value: jdbc:postgresql://postgres:5432/dgu_cap
+            - name: SPRING_DATASOURCE_USERNAME
+              value: dgu_cap
+            - name: SPRING_DATASOURCE_PASSWORD
+              value: dgu_cap_local
+            - name: SPRING_DATA_REDIS_HOST
+              value: redis
+            - name: SPRING_DATA_REDIS_PORT
+              value: "6379"
+            - name: PROMETHEUS_URL
+              value: http://kube-prometheus-stack-prometheus.monitoring:9090
+            - name: LOKI_URL
+              value: http://loki-gateway.monitoring:80
+            - name: AI_URL
+              value: http://ai:8000

--- a/eks/manifests/base/backend/kustomization.yaml
+++ b/eks/manifests/base/backend/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - rbac.yaml
+  - deployment.yaml
+  - service.yaml

--- a/eks/manifests/base/backend/rbac.yaml
+++ b/eks/manifests/base/backend/rbac.yaml
@@ -1,0 +1,33 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: backend
+  namespace: default
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: backend-reader
+rules:
+  - apiGroups: [""]
+    resources: ["pods", "nodes", "namespaces", "events", "services"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["apps"]
+    resources: ["deployments", "replicasets", "daemonsets", "statefulsets"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["metrics.k8s.io"]
+    resources: ["pods", "nodes"]
+    verbs: ["get", "list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: backend-reader
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: backend-reader
+subjects:
+  - kind: ServiceAccount
+    name: backend
+    namespace: default

--- a/eks/manifests/base/backend/service.yaml
+++ b/eks/manifests/base/backend/service.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: backend
+spec:
+  selector:
+    app: backend
+  ports:
+    - port: 8080
+      targetPort: 8080
+  type: ClusterIP

--- a/eks/manifests/base/postgres/deployment.yaml
+++ b/eks/manifests/base/postgres/deployment.yaml
@@ -1,0 +1,33 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: postgres
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: postgres
+  template:
+    metadata:
+      labels:
+        app: postgres
+    spec:
+      containers:
+        - name: postgres
+          image: postgres:16-alpine
+          ports:
+            - containerPort: 5432
+          env:
+            - name: POSTGRES_DB
+              value: dgu_cap
+            - name: POSTGRES_USER
+              value: dgu_cap
+            - name: POSTGRES_PASSWORD
+              value: dgu_cap_local
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              cpu: 200m
+              memory: 256Mi

--- a/eks/manifests/base/postgres/kustomization.yaml
+++ b/eks/manifests/base/postgres/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - deployment.yaml
+  - service.yaml

--- a/eks/manifests/base/postgres/service.yaml
+++ b/eks/manifests/base/postgres/service.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: postgres
+spec:
+  selector:
+    app: postgres
+  ports:
+    - port: 5432
+      targetPort: 5432
+  type: ClusterIP

--- a/eks/manifests/base/redis/deployment.yaml
+++ b/eks/manifests/base/redis/deployment.yaml
@@ -1,0 +1,26 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: redis
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: redis
+  template:
+    metadata:
+      labels:
+        app: redis
+    spec:
+      containers:
+        - name: redis
+          image: redis:7-alpine
+          ports:
+            - containerPort: 6379
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              cpu: 100m
+              memory: 128Mi

--- a/eks/manifests/base/redis/kustomization.yaml
+++ b/eks/manifests/base/redis/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - deployment.yaml
+  - service.yaml

--- a/eks/manifests/base/redis/service.yaml
+++ b/eks/manifests/base/redis/service.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: redis
+spec:
+  selector:
+    app: redis
+  ports:
+    - port: 6379
+      targetPort: 6379
+  type: ClusterIP

--- a/eks/manifests/overlays/eks/ai/kustomization.yaml
+++ b/eks/manifests/overlays/eks/ai/kustomization.yaml
@@ -1,0 +1,11 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../../base/ai
+
+patches:
+  - path: patch.yaml
+    target:
+      kind: Deployment
+      name: ai

--- a/eks/manifests/overlays/eks/ai/patch.yaml
+++ b/eks/manifests/overlays/eks/ai/patch.yaml
@@ -1,0 +1,10 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ai
+spec:
+  template:
+    spec:
+      containers:
+        - name: ai
+          imagePullPolicy: Always

--- a/eks/manifests/overlays/eks/backend/kustomization.yaml
+++ b/eks/manifests/overlays/eks/backend/kustomization.yaml
@@ -1,0 +1,11 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../../base/backend
+
+patches:
+  - path: patch.yaml
+    target:
+      kind: Deployment
+      name: backend

--- a/eks/manifests/overlays/eks/backend/patch.yaml
+++ b/eks/manifests/overlays/eks/backend/patch.yaml
@@ -1,0 +1,10 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: backend
+spec:
+  template:
+    spec:
+      containers:
+        - name: backend
+          imagePullPolicy: Always

--- a/eks/manifests/overlays/eks/postgres/kustomization.yaml
+++ b/eks/manifests/overlays/eks/postgres/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../../base/postgres

--- a/eks/manifests/overlays/eks/redis/kustomization.yaml
+++ b/eks/manifests/overlays/eks/redis/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../../base/redis

--- a/eks/manifests/overlays/kind/ai/kustomization.yaml
+++ b/eks/manifests/overlays/kind/ai/kustomization.yaml
@@ -1,0 +1,11 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../../base/ai
+
+patches:
+  - path: patch.yaml
+    target:
+      kind: Deployment
+      name: ai

--- a/eks/manifests/overlays/kind/ai/patch.yaml
+++ b/eks/manifests/overlays/kind/ai/patch.yaml
@@ -1,0 +1,10 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ai
+spec:
+  template:
+    spec:
+      containers:
+        - name: ai
+          imagePullPolicy: Never

--- a/eks/manifests/overlays/kind/backend/kustomization.yaml
+++ b/eks/manifests/overlays/kind/backend/kustomization.yaml
@@ -1,0 +1,11 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../../base/backend
+
+patches:
+  - path: patch.yaml
+    target:
+      kind: Deployment
+      name: backend

--- a/eks/manifests/overlays/kind/backend/patch.yaml
+++ b/eks/manifests/overlays/kind/backend/patch.yaml
@@ -1,0 +1,10 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: backend
+spec:
+  template:
+    spec:
+      containers:
+        - name: backend
+          imagePullPolicy: Never

--- a/eks/manifests/overlays/kind/postgres/kustomization.yaml
+++ b/eks/manifests/overlays/kind/postgres/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../../base/postgres

--- a/eks/manifests/overlays/kind/redis/kustomization.yaml
+++ b/eks/manifests/overlays/kind/redis/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../../base/redis


### PR DESCRIPTION
## 관련 이슈
closes #1

## 변경 사항
- `eks/manifests/base/` — 환경 공통 K8s 매니페스트 (backend, ai, postgres, redis)
- `eks/manifests/overlays/kind/` — kind 전용 패치 (imagePullPolicy: Never, 서비스별 분리)
- `eks/manifests/overlays/eks/` — EKS 전용 패치 (imagePullPolicy: Always, 서비스별 분리)
- `eks/apps/` — ArgoCD App of Apps 매니페스트 (root + backend/ai/postgres/redis)
- `eks/README.md` — ArgoCD 설치 및 GitOps 흐름 가이드

## 작업 내용 상세
**Kustomize overlays 구조**
- `base/` 에 공통 매니페스트를 두고, `overlays/kind/` 와 `overlays/eks/` 에서 환경별 차이만 patch
- kind는 `imagePullPolicy: Never` (kind load로 로드한 이미지), EKS는 `imagePullPolicy: Always` (ECR)
- EKS 전환 시 `eks/apps/` 의 path 한 줄만 변경하면 됨

**App of Apps 패턴**
- `root.yaml` 이 `eks/apps/` 디렉토리를 감시하며 하위 Application을 자동 등록
- 서비스별로 ArgoCD Application을 분리해 독립적인 sync/rollback 가능
- Git push → ArgoCD 자동 감지 → 클러스터 자동 반영

## 체크리스트
- [x] 민감 정보 (access key 등) 코드에 포함되지 않음
- [x] kind / EKS 환경 분기 확인 (Kustomize overlays)
- [x] App of Apps 패턴으로 서비스별 독립 관리 구성