### PR TITLE
feat: ai deployment에 ai-secret envFrom 추가 (closes #12)

### DIFF
--- a/k8s/manifests/base/ai/deployment.yaml
+++ b/k8s/manifests/base/ai/deployment.yaml
@@ -15,5 +15,8 @@ spec:
       containers:
         - name: ai
           image: 428185450315.dkr.ecr.ap-northeast-2.amazonaws.com/dgu-cap-ai:latest
+          envFrom:
+            - secretRef:
+                name: ai-secret
           ports:
             - containerPort: 8000


### PR DESCRIPTION
## 관련 이슈
closes #12

## 변경 사항
- `k8s/manifests/base/ai/deployment.yaml` containers에 `envFrom` 추가
- `secretRef.name: ai-secret` 으로 Secret 주입 설정

## 작업 내용 상세
ai 모듈 컨테이너가 기동 시 `ai-secret` Kubernetes Secret의 모든 키를 환경변수로 자동 주입받도록 `envFrom.secretRef` 방식을 사용했습니다.

## 체크리스트
- [ ] `terraform plan` 실행하여 의도한 변경만 포함되어 있음을 확인
- [ ] 리소스 태그 (Name, Environment) 누락 없음
- [ ] 민감 정보 (access key 등) 코드에 포함되지 않음