### PR TITLE
feat: ai deployment에 ai-secret envFrom 추가 (closes #14)

### DIFF
--- a/k8s/manifests/overlays/kind/ai/patch.yaml
+++ b/k8s/manifests/overlays/kind/ai/patch.yaml
@@ -8,3 +8,6 @@ spec:
       containers:
         - name: ai
           imagePullPolicy: Never
+          envFrom:
+            - secretRef:
+                name: ai-secret


### PR DESCRIPTION
## 관련 이슈
closes #14

## 변경 사항
- `k8s/manifests/overlays/kind/ai/patch.yaml`에 envFrom secretRef 추가

## 작업 내용 상세
AI Pod 기동 시 `OPENAI_API_KEY` 환경변수 미주입으로 `openai.OpenAIError: Missing credentials` 발생 후 CrashLoopBackOff. kind overlay patch에 `envFrom: secretRef: ai-secret` 추가로 해결. Secret 파일 자체는 gitignore 처리되어 수동 적용 필요.

## 체크리스트
- [x] 민감 정보 (API key 등) 코드에 포함되지 않음
- [x] secret.yaml은 gitignore로 관리됨