### PR TITLE
feat: ai pod ML 모델 파일 PVC 마운트 추가

### DIFF
--- a/k8s/manifests/base/ai/deployment.yaml
+++ b/k8s/manifests/base/ai/deployment.yaml
@@ -20,3 +20,10 @@ spec:
                 name: ai-secret
           ports:
             - containerPort: 8000
+          volumeMounts:
+            - name: model-storage
+              mountPath: /app/models
+      volumes:
+        - name: model-storage
+          persistentVolumeClaim:
+            claimName: ai-model-pvc

--- a/k8s/manifests/base/ai/pvc.yaml
+++ b/k8s/manifests/base/ai/pvc.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: ai-model-pvc
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 100Mi


### PR DESCRIPTION
## 문제
현재 ai pod가 재시작될 때마다 컨테이너 내부에 저장된 ML 모델 파일
(isolation_forest.pkl)이 삭제됨.

이로 인해 pod 재시작 시마다:
- 학습된 모델이 사라져 ML 탐지가 비활성화됨
- POST /metrics로 정상 데이터를 200개 다시 수집할 때까지 ML 탐지 불가
- 200개 수집까지 약 50분 소요 (1분마다 4개 수신 기준)

## 해결 방법
PersistentVolumeClaim(PVC)을 생성하여 /app/models 디렉토리를 마운트.
pod가 재시작되어도 모델 파일이 유지되어 즉시 ML 탐지 가능.

## 작업 내용
- manifests/base/ai/pvc.yaml 추가
- manifests/base/ai/deployment.yaml에 volumeMounts 및 volumes 추가

## 기대 효과
pod 재시작 후에도 기존 학습된 모델을 바로 로드하여 ML 탐지 중단 없이 운영 가능.
