### PR TITLE
chore: .gitignore에 Lambda 빌드 아티팩트(.zip) 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,9 @@ override.tf.json
 # Kubernetes Secrets (실제값 포함 파일)
 k8s/**/secret.yaml
 
+# Lambda 빌드 아티팩트
+*.zip
+
 # 에디터 / OS
 .DS_Store
 Thumbs.db


### PR DESCRIPTION
## Summary
- `.gitignore`에 `*.zip` 패턴 추가 (Lambda 빌드 아티팩트 제외)
- `handler.py`는 이미 main에 포함되어 있어 별도 작업 불필요

closes #26

## Test plan
- [ ] `handler.zip`이 `git status`에서 untracked로 표시되지 않는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)