### PR TITLE
fix: ai deployment volumeMount 경로 /app/models → /code/models

### DIFF
--- a/k8s/manifests/base/ai/deployment.yaml
+++ b/k8s/manifests/base/ai/deployment.yaml
@@ -22,7 +22,7 @@ spec:
             - containerPort: 8000
           volumeMounts:
             - name: model-storage
-              mountPath: /app/models
+              mountPath: /code/models
       volumes:
         - name: model-storage
           persistentVolumeClaim:


### PR DESCRIPTION
## 변경 사항
- ai/deployment.yaml mountPath: /app/models → /code/models
