### PR TITLE
fix: EKS 노드그룹 인스턴스 타입 Free Tier 호환으로 변경

### DIFF
--- a/terraform/eks-nodegroup.tf
+++ b/terraform/eks-nodegroup.tf
@@ -6,7 +6,7 @@ resource "aws_eks_node_group" "main" {
   # 각 AZ의 Private Subnet에 노드 분산 배치
   subnet_ids = aws_subnet.private[*].id
 
-  instance_types = ["t3.medium"]
+  instance_types = ["t3.small"]
   ami_type       = "AL2023_x86_64_STANDARD"
   capacity_type  = "ON_DEMAND"
 


### PR DESCRIPTION
## Summary
- EKS 노드그룹 인스턴스 타입 `t3.medium` → `t3.small` 변경
- AWS 계정 Free Tier 제한으로 `t3.medium` 런치 실패 해결
- closes #30

## 작업
- [ ] 머지 후 `terraform apply` 실행 필요 (노드그룹 재생성 ~25분 소요)

🤖 Generated with [Claude Code](https://claude.com/claude-code)