### PR TITLE
fix: ArgoCD overlay kind → eks 전환 + ai PVC 포함 (closes #33)

### DIFF
--- a/k8s/apps/ai.yaml
+++ b/k8s/apps/ai.yaml
@@ -10,7 +10,7 @@ spec:
   source:
     repoURL: https://github.com/DGU-CAP/infra.git
     targetRevision: HEAD
-    path: k8s/manifests/overlays/kind/ai  # EKS 전환 시 overlays/k8s/ai 로 변경
+    path: k8s/manifests/overlays/eks/ai
   destination:
     server: https://kubernetes.default.svc
     namespace: default

--- a/k8s/apps/backend.yaml
+++ b/k8s/apps/backend.yaml
@@ -10,7 +10,7 @@ spec:
   source:
     repoURL: https://github.com/DGU-CAP/infra.git
     targetRevision: HEAD
-    path: k8s/manifests/overlays/kind/backend  # EKS 전환 시 overlays/k8s/backend 로 변경
+    path: k8s/manifests/overlays/eks/backend
   destination:
     server: https://kubernetes.default.svc
     namespace: default

--- a/k8s/apps/frontend.yaml
+++ b/k8s/apps/frontend.yaml
@@ -10,7 +10,7 @@ spec:
   source:
     repoURL: https://github.com/DGU-CAP/infra.git
     targetRevision: HEAD
-    path: k8s/manifests/overlays/kind/frontend  # EKS 전환 시 overlays/eks/frontend 로 변경
+    path: k8s/manifests/overlays/eks/frontend
   destination:
     server: https://kubernetes.default.svc
     namespace: default

--- a/k8s/apps/postgres.yaml
+++ b/k8s/apps/postgres.yaml
@@ -10,7 +10,7 @@ spec:
   source:
     repoURL: https://github.com/DGU-CAP/infra.git
     targetRevision: HEAD
-    path: k8s/manifests/overlays/kind/postgres  # EKS 전환 시 overlays/k8s/postgres 로 변경
+    path: k8s/manifests/overlays/eks/postgres
   destination:
     server: https://kubernetes.default.svc
     namespace: default

--- a/k8s/apps/redis.yaml
+++ b/k8s/apps/redis.yaml
@@ -10,7 +10,7 @@ spec:
   source:
     repoURL: https://github.com/DGU-CAP/infra.git
     targetRevision: HEAD
-    path: k8s/manifests/overlays/kind/redis  # EKS 전환 시 overlays/k8s/redis 로 변경
+    path: k8s/manifests/overlays/eks/redis
   destination:
     server: https://kubernetes.default.svc
     namespace: default

--- a/k8s/manifests/base/ai/kustomization.yaml
+++ b/k8s/manifests/base/ai/kustomization.yaml
@@ -4,3 +4,4 @@ kind: Kustomization
 resources:
   - deployment.yaml
   - service.yaml
+  - pvc.yaml


### PR DESCRIPTION
## Summary
- 자식 Application 5개(`ai`, `backend`, `frontend`, `postgres`, `redis`)의 `path`를 `overlays/kind/...` → `overlays/eks/...`로 변경
- `k8s/manifests/base/ai/kustomization.yaml`에 `pvc.yaml` 추가 — ai Pod의 `ai-model-pvc` Pending 문제 해결

Closes #33

## 배경
EKS 클러스터에 ArgoCD를 새로 부트스트랩한 결과:
- `backend`, `frontend`: kind overlay의 `imagePullPolicy: Never` 때문에 `ErrImageNeverPull`
- `ai`: `ai-model-pvc` 미생성으로 `Pending`
- `postgres`, `redis`: 공식 이미지라 정상 Running

## 후속 (이 PR 외)
- `ai-secret`은 `.gitignore` 대상 — ArgoCD가 sync 불가. SealedSecrets/ExternalSecrets 도입 또는 수동 apply 필요
- `base/ai/secret.yaml`의 OpenAI 키가 실제 사용 중이면 로테이션 고려

## Test plan
- [ ] PR 머지 후 ArgoCD UI에서 자식 앱 5개 모두 `Synced` + `Healthy` 확인
- [ ] `kubectl get pods -A`에서 backend/frontend/ai 모두 Running 확인
- [ ] ai-secret 수동 apply 후 ai Pod envFrom 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)