### PR TITLE
feat: EBS CSI Driver addon + IRSA 추가 (closes #35)

### DIFF
--- a/terraform/ebs-csi.tf
+++ b/terraform/ebs-csi.tf
@@ -1,0 +1,64 @@
+# ──────────────────────────────────────────
+# EBS CSI Driver IRSA 역할
+# ──────────────────────────────────────────
+data "aws_iam_policy_document" "ebs_csi_assume_role" {
+  statement {
+    effect = "Allow"
+
+    principals {
+      type        = "Federated"
+      identifiers = [aws_iam_openid_connect_provider.eks.arn]
+    }
+
+    actions = ["sts:AssumeRoleWithWebIdentity"]
+
+    condition {
+      test     = "StringEquals"
+      variable = "${local.oidc_provider}:aud"
+      values   = ["sts.amazonaws.com"]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "${local.oidc_provider}:sub"
+      values   = ["system:serviceaccount:kube-system:ebs-csi-controller-sa"]
+    }
+  }
+}
+
+resource "aws_iam_role" "ebs_csi" {
+  name               = "${var.project_name}-ebs-csi-role"
+  assume_role_policy = data.aws_iam_policy_document.ebs_csi_assume_role.json
+
+  tags = {
+    Name        = "${var.project_name}-ebs-csi-role"
+    Environment = var.environment
+  }
+}
+
+resource "aws_iam_role_policy_attachment" "ebs_csi" {
+  role       = aws_iam_role.ebs_csi.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonEBSCSIDriverPolicy"
+}
+
+# ──────────────────────────────────────────
+# EBS CSI Driver EKS Addon
+# ──────────────────────────────────────────
+resource "aws_eks_addon" "ebs_csi" {
+  cluster_name             = aws_eks_cluster.main.name
+  addon_name               = "aws-ebs-csi-driver"
+  service_account_role_arn = aws_iam_role.ebs_csi.arn
+
+  resolve_conflicts_on_create = "OVERWRITE"
+  resolve_conflicts_on_update = "OVERWRITE"
+
+  tags = {
+    Name        = "${var.project_name}-ebs-csi-addon"
+    Environment = var.environment
+  }
+
+  depends_on = [
+    aws_eks_node_group.main,
+    aws_iam_role_policy_attachment.ebs_csi,
+  ]
+}


### PR DESCRIPTION
## Summary
- `terraform/ebs-csi.tf` 추가
  - EBS CSI Controller용 IRSA (`AmazonEBSCSIDriverPolicy` 관리형 정책 사용)
  - `aws_eks_addon "aws-ebs-csi-driver"`

Closes #35

## 배경
EKS 1.23+에서 in-tree EBS 볼륨 플러그인이 deprecate되어, 동적 EBS 프로비저닝을 위해 별도 add-on 필요. 현재 `ai-model-pvc` Pending 상태에 머물러 `ai` Pod이 스케줄링되지 못함.

## Apply 노트
- 적용 시 `-target=aws_eks_addon.ebs_csi`로 범위 제한 (전체 plan에는 무관한 ALB Controller drift가 잡혀있음 — 별도 이슈로 처리)
- 적용 후 ai-model-pvc가 자동으로 Bound 전환됨

## Test plan
- [ ] `terraform apply -target=aws_eks_addon.ebs_csi` 성공
- [ ] `kubectl get pods -n kube-system -l app.kubernetes.io/name=aws-ebs-csi-driver` 모두 Running
- [ ] `kubectl get pvc -n default ai-model-pvc` STATUS=Bound
- [ ] `kubectl get pods -n default -l app=ai` STATUS=Running

🤖 Generated with [Claude Code](https://claude.com/claude-code)