### PR TITLE
fix: EKS 노드그룹 desired_size 2→3 (closes #39)

### DIFF
--- a/terraform/eks-nodegroup.tf
+++ b/terraform/eks-nodegroup.tf
@@ -11,7 +11,7 @@ resource "aws_eks_node_group" "main" {
   capacity_type  = "ON_DEMAND"
 
   scaling_config {
-    desired_size = 2
+    desired_size = 3
     min_size     = 2
     max_size     = 3
   }


### PR DESCRIPTION
## Summary
- `scaling_config.desired_size` 2 → 3
- max_size 3은 유지, t3.small 유지 (#30 비용 절감 결정 존중)

## 영향
- pod cap 22 → 33 (margin 12)
- 추가 비용 ≈ $0.026/h ≈ 월 $19

Closes #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)