### PR TITLE
feat: gp3 default StorageClass + helm/kubernetes provider 활성화 (closes #45)

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -22,6 +22,10 @@ terraform {
       source  = "hashicorp/archive"
       version = "~> 2.0"
     }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.30"
+    }
   }
 }
 # backend 설정은 backend.tf 참고
@@ -34,17 +38,27 @@ locals {
   eks_cluster_name = "${var.project_name}-eks"
 }
 
-#provider "helm" {
-#  kubernetes {
-#    host                   = aws_eks_cluster.main.endpoint
-#    cluster_ca_certificate = base64decode(aws_eks_cluster.main.certificate_authority[0].data)
-#    exec {
-#      api_version = "client.authentication.k8s.io/v1beta1"
-#      command     = "aws"
-#      args        = ["eks", "get-token", "--cluster-name", local.eks_cluster_name, "--region", var.aws_region]
-#    }
-#  }
-#}
+provider "helm" {
+  kubernetes {
+    host                   = aws_eks_cluster.main.endpoint
+    cluster_ca_certificate = base64decode(aws_eks_cluster.main.certificate_authority[0].data)
+    exec {
+      api_version = "client.authentication.k8s.io/v1beta1"
+      command     = "aws"
+      args        = ["eks", "get-token", "--cluster-name", local.eks_cluster_name, "--region", var.aws_region]
+    }
+  }
+}
+
+provider "kubernetes" {
+  host                   = aws_eks_cluster.main.endpoint
+  cluster_ca_certificate = base64decode(aws_eks_cluster.main.certificate_authority[0].data)
+  exec {
+    api_version = "client.authentication.k8s.io/v1beta1"
+    command     = "aws"
+    args        = ["eks", "get-token", "--cluster-name", local.eks_cluster_name, "--region", var.aws_region]
+  }
+}
 
 # ──────────────────────────────────────────
 # VPC

--- a/terraform/storage.tf
+++ b/terraform/storage.tf
@@ -1,0 +1,39 @@
+# ──────────────────────────────────────────
+# gp3 StorageClass (default)
+# ──────────────────────────────────────────
+resource "kubernetes_storage_class" "gp3" {
+  metadata {
+    name = "gp3"
+    annotations = {
+      "storageclass.kubernetes.io/is-default-class" = "true"
+    }
+  }
+
+  storage_provisioner    = "ebs.csi.aws.com"
+  reclaim_policy         = "Delete"
+  volume_binding_mode    = "WaitForFirstConsumer"
+  allow_volume_expansion = true
+
+  parameters = {
+    type   = "gp3"
+    fsType = "ext4"
+  }
+
+  depends_on = [aws_eks_addon.ebs_csi]
+}
+
+# ──────────────────────────────────────────
+# 기존 gp2 SC에서 default 표시 제거 (drift 해소)
+# ──────────────────────────────────────────
+resource "kubernetes_annotations" "gp2_not_default" {
+  api_version = "storage.k8s.io/v1"
+  kind        = "StorageClass"
+  metadata {
+    name = "gp2"
+  }
+  annotations = {
+    "storageclass.kubernetes.io/is-default-class" = "false"
+  }
+
+  depends_on = [kubernetes_storage_class.gp3]
+}


### PR DESCRIPTION
## Summary
- `terraform/main.tf`
  - `required_providers`에 `hashicorp/kubernetes` 추가
  - 주석 처리되어 있던 `provider "helm"` 블록 활성화 (ALB Controller apply가 'Kubernetes cluster unreachable' 로 실패하던 원인)
  - `provider "kubernetes"` 블록 추가
- `terraform/storage.tf` 신규
  - `kubernetes_storage_class.gp3`: gp3 default SC (`is-default-class=true`, WaitForFirstConsumer, expansion 허용)
  - `kubernetes_annotations.gp2_not_default`: 기존 gp2 SC의 default annotation 해제 (drift 해소)

## 영향
- 기존 `ai-model-pvc`(gp2)는 영향 없음. 새 PVC는 gp3로 생성.
- ALB Controller / SealedSecrets controller 등 향후 helm_release apply 가능해짐.

Closes #45

## Test plan
- [ ] `terraform init` 성공 (kubernetes provider 다운로드)
- [ ] `terraform plan` 정상
- [ ] 머지 후 `terraform apply` → `kubectl get sc`에서 gp3 default, gp2 not-default 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)