### PR TITLE
feat: ArgoCD로 모니터링 스택(Prometheus+Loki+Promtail) 도입 (closes #49)

### DIFF
--- a/k8s/apps/monitoring.yaml
+++ b/k8s/apps/monitoring.yaml
@@ -1,0 +1,91 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: kube-prometheus-stack
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+  sources:
+    - repoURL: https://prometheus-community.github.io/helm-charts
+      chart: kube-prometheus-stack
+      targetRevision: 65.8.1
+      helm:
+        releaseName: kube-prometheus-stack
+        valueFiles:
+          - $values/k8s/manifests/base/monitoring/values/kube-prometheus-stack.yaml
+    - repoURL: https://github.com/DGU-CAP/infra.git
+      targetRevision: HEAD
+      ref: values
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: monitoring
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: loki
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+  sources:
+    - repoURL: https://grafana.github.io/helm-charts
+      chart: loki
+      targetRevision: 6.16.0
+      helm:
+        releaseName: loki
+        valueFiles:
+          - $values/k8s/manifests/base/monitoring/values/loki.yaml
+    - repoURL: https://github.com/DGU-CAP/infra.git
+      targetRevision: HEAD
+      ref: values
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: monitoring
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: promtail
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+  sources:
+    - repoURL: https://grafana.github.io/helm-charts
+      chart: promtail
+      targetRevision: 6.16.6
+      helm:
+        releaseName: promtail
+        valueFiles:
+          - $values/k8s/manifests/base/monitoring/values/promtail.yaml
+    - repoURL: https://github.com/DGU-CAP/infra.git
+      targetRevision: HEAD
+      ref: values
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: monitoring
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/k8s/manifests/base/monitoring/values/kube-prometheus-stack.yaml
+++ b/k8s/manifests/base/monitoring/values/kube-prometheus-stack.yaml
@@ -1,0 +1,74 @@
+grafana:
+  enabled: false
+
+alertmanager:
+  enabled: false
+
+prometheus:
+  prometheusSpec:
+    replicas: 1
+    retention: 7d
+    retentionSize: 4GiB
+
+    resources:
+      requests:
+        cpu: 100m
+        memory: 256Mi
+      limits:
+        cpu: 500m
+        memory: 768Mi
+
+    storageSpec:
+      volumeClaimTemplate:
+        spec:
+          accessModes: ["ReadWriteOnce"]
+          resources:
+            requests:
+              storage: 5Gi
+
+    serviceMonitorSelectorNilUsesHelmValues: false
+    podMonitorSelectorNilUsesHelmValues: false
+    ruleSelectorNilUsesHelmValues: false
+    probeSelectorNilUsesHelmValues: false
+
+prometheusOperator:
+  resources:
+    requests:
+      cpu: 50m
+      memory: 64Mi
+    limits:
+      cpu: 200m
+      memory: 256Mi
+
+nodeExporter:
+  enabled: true
+
+kubeStateMetrics:
+  enabled: true
+
+kube-state-metrics:
+  resources:
+    requests:
+      cpu: 50m
+      memory: 64Mi
+    limits:
+      cpu: 100m
+      memory: 128Mi
+
+prometheus-node-exporter:
+  resources:
+    requests:
+      cpu: 50m
+      memory: 32Mi
+    limits:
+      cpu: 100m
+      memory: 64Mi
+
+kubeControllerManager:
+  enabled: false
+kubeScheduler:
+  enabled: false
+kubeEtcd:
+  enabled: false
+kubeProxy:
+  enabled: false

--- a/k8s/manifests/base/monitoring/values/loki.yaml
+++ b/k8s/manifests/base/monitoring/values/loki.yaml
@@ -1,0 +1,67 @@
+loki:
+  auth_enabled: false
+
+  commonConfig:
+    replication_factor: 1
+
+  storage:
+    type: filesystem
+
+  schemaConfig:
+    configs:
+      - from: "2024-01-01"
+        store: tsdb
+        object_store: filesystem
+        schema: v13
+        index:
+          prefix: index_
+          period: 24h
+
+  limits_config:
+    retention_period: 72h
+    reject_old_samples: true
+    reject_old_samples_max_age: 168h
+
+  compactor:
+    retention_enabled: true
+    delete_request_store: filesystem
+
+deploymentMode: SingleBinary
+
+singleBinary:
+  replicas: 1
+
+  persistence:
+    enabled: true
+    size: 5Gi
+
+  resources:
+    requests:
+      cpu: 100m
+      memory: 128Mi
+    limits:
+      cpu: 300m
+      memory: 512Mi
+
+backend:
+  replicas: 0
+read:
+  replicas: 0
+write:
+  replicas: 0
+
+minio:
+  enabled: false
+
+gateway:
+  enabled: false
+
+chunksCache:
+  enabled: false
+resultsCache:
+  enabled: false
+
+test:
+  enabled: false
+lokiCanary:
+  enabled: false

--- a/k8s/manifests/base/monitoring/values/promtail.yaml
+++ b/k8s/manifests/base/monitoring/values/promtail.yaml
@@ -1,0 +1,11 @@
+config:
+  clients:
+    - url: http://loki.monitoring.svc.cluster.local:3100/loki/api/v1/push
+
+resources:
+  requests:
+    cpu: 50m
+    memory: 64Mi
+  limits:
+    cpu: 100m
+    memory: 128Mi


### PR DESCRIPTION
## Summary
- ArgoCD Application 3개 추가: `kube-prometheus-stack`, `loki`, `promtail` (모두 ns `monitoring`)
- Helm multi-source 패턴 — chart는 공식 repo, values는 인프라 레포(`$values`)에서 참조
- Grafana 제외 (서비스가 직접 시각화). Alertmanager 비활성 (dev 비용 절감)

## 결정
- replicas=1, prometheus retention 7d, loki retention 72h
- PVC 5Gi (default SC gp3)
- EKS 관리형이라 kubeControllerManager/Scheduler/Etcd/Proxy 비활성
- chart: kube-prometheus-stack 65.8.1 / loki 6.16.0 / promtail 6.16.6

Closes #49

## Test plan
- [ ] 머지 후 ArgoCD UI에서 `kube-prometheus-stack`, `loki`, `promtail` 모두 Synced/Healthy
- [ ] `kubectl get pods -n monitoring` 모두 Running
- [ ] `kubectl port-forward -n monitoring svc/kube-prometheus-stack-prometheus 9090` → http://localhost:9090 에서 메트릭 조회
- [ ] `kubectl port-forward -n monitoring svc/loki 3100` → `curl http://localhost:3100/ready` OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)