### PR TITLE
fix: EKS 노드그룹 t3.small × 3→4 확장 (closes #51)

### DIFF
--- a/terraform/eks-nodegroup.tf
+++ b/terraform/eks-nodegroup.tf
@@ -11,9 +11,9 @@ resource "aws_eks_node_group" "main" {
   capacity_type  = "ON_DEMAND"
 
   scaling_config {
-    desired_size = 3
+    desired_size = 4
     min_size     = 2
-    max_size     = 3
+    max_size     = 4
   }
 
   update_config {


### PR DESCRIPTION
## Summary
- `scaling_config.desired_size` 3 → 4
- `scaling_config.max_size` 3 → 4
- t3.small 유지

## 영향
- pod cap 33 → 44 (margin 11)
- 추가 비용 ~$13/20일 (~₩18,000) — EKS 항상 켜놓을 때 기준

Closes #51

🤖 Generated with [Claude Code](https://claude.com/claude-code)