### PR TITLE
chore: EKS k8s_version 1.32 → 1.34 (closes #53)

### DIFF
--- a/terraform/terraform.tfvars
+++ b/terraform/terraform.tfvars
@@ -8,7 +8,7 @@ availability_zones = ["ap-northeast-2a", "ap-northeast-2c"]
 public_subnet_cidrs  = ["10.0.1.0/24", "10.0.2.0/24"]
 private_subnet_cidrs = ["10.0.101.0/24", "10.0.102.0/24"]
 
-k8s_version = "1.32"
+k8s_version = "1.34"
 domain_name = "" # HTTPS 사용 시 도메인 입력 (예: "monitoring.example.com")
 
 # 팀원 IAM ARN 목록 — aws sts get-caller-identity --query Arn --output text 로 확인

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -43,7 +43,7 @@ variable "private_subnet_cidrs" {
 variable "k8s_version" {
   description = "EKS Kubernetes 버전"
   type        = string
-  default     = "1.32"
+  default     = "1.34"
 }
 
 variable "domain_name" {


### PR DESCRIPTION
## Summary
- Extended Support 페널티 제거 위해 EKS 버전 1.32 → 1.34
- 1.32: Standard Support 2026-03-23 종료 → 컨트롤 플레인 $0.10/h + Extended Support $0.60/h
- 1.34: Standard Support 2026-12-02까지 → 페널티 없음
- 클러스터는 destroy된 상태이므로 다음 `terraform apply` 때 1.34로 신규 생성됨

## Cost impact
| 항목 | Before (1.32) | After (1.34) |
|---|---|---|
| 시간당 | $0.70 | $0.10 |
| 24/7 월 | ~$511 | ~$73 |

월 약 **$438** 절감.

## Test plan
- [ ] `terraform plan` 후 `aws_eks_cluster.main`이 1.34로 생성되는지 확인
- [ ] `terraform apply` 후 `aws eks describe-cluster --name dgu-cap-eks --query cluster.version` → `1.34` 확인
- [ ] `aws ce get-cost-and-usage`로 `APN2-AmazonEKS-Hours:extendedSupport` 항목이 더 이상 청구되지 않는지 확인

Closes #53