### PR TITLE
feat: 시크릿 관리를 External Secrets + AWS Secrets Manager로 전환 (#55)

### DIFF
--- a/k8s/README.md
+++ b/k8s/README.md
@@ -106,7 +106,54 @@ path: k8s/manifests/overlays/k8s/backend
 
 ---
 
-## SealedSecrets 운영 가이드
+## 시크릿 관리 (EKS): External Secrets + AWS Secrets Manager
+
+EKS 환경의 시크릿은 **External Secrets Operator(ESO)** 가 **AWS Secrets Manager**에서 읽어와 K8s Secret으로 만든다. 비밀값은 git에 일절 남지 않고 Secrets Manager에만 보관되며, ESO는 IRSA로 읽기 권한만 갖는다.
+
+```
+Secrets Manager (dgu-cap/backend, dgu-cap/ai)
+        │ ESO가 IRSA로 읽음
+        ▼
+ExternalSecret (overlays/eks/<app>) ── ClusterSecretStore(aws-secretsmanager)
+        ▼
+K8s Secret (backend-secret / ai-secret) 자동 생성 → Pod가 secretRef로 사용
+```
+
+### 1. ESO + IRSA 배포 (1회, terraform)
+
+```bash
+cd terraform
+export AWS_PROFILE=dgu-cap
+terraform apply   # external-secrets.tf (IRSA 역할 + helm_release.external_secrets)
+```
+
+### 2. Secrets Manager에 시크릿 등록 (운영자)
+
+`dgu-cap/<app>` 이름으로 **JSON** 시크릿을 만든다. 키 이름이 그대로 Pod 환경변수가 된다.
+
+```bash
+# backend: deployment의 envFrom(backend-secret)이 쓰는 키들
+aws secretsmanager create-secret --name dgu-cap/backend \
+  --secret-string '{"SPRING_DATASOURCE_PASSWORD":"...","JWT_SECRET":"..."}'
+
+# ai
+aws secretsmanager create-secret --name dgu-cap/ai \
+  --secret-string '{"OPENAI_API_KEY":"sk-..."}'
+```
+
+값 변경(회전)은 `aws secretsmanager put-secret-value`로 갱신하면 ESO가 `refreshInterval`(1h)마다 자동 반영한다.
+
+### 3. 동기화
+
+`k8s/apps/`의 `secretstore`(ClusterSecretStore) → backend/ai `ExternalSecret` 순으로 ArgoCD가 동기화하면 Secret이 자동 생성된다. 별도 수동 작업 불필요.
+
+> 로컬(kind)은 Secrets Manager에 접근할 수 없으므로 [LOCAL_DEV.md](./LOCAL_DEV.md)의 수동 `kubectl create secret` 방식을 유지한다(ExternalSecret은 eks overlay에만 존재).
+
+---
+
+## (구) SealedSecrets 운영 가이드
+
+> EKS는 위 External Secrets 방식으로 전환됨. SealedSecrets는 후속 정리 예정(컨트롤러만 설치된 상태).
 
 평문 secret(`*/secret.yaml`)은 git에 못 올리지만, SealedSecrets로 봉인하면 안전하게 커밋할 수 있다.
 

--- a/k8s/apps/secretstore.yaml
+++ b/k8s/apps/secretstore.yaml
@@ -1,0 +1,23 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: secretstore
+  namespace: argocd
+  annotations:
+    # backend/ai의 ExternalSecret보다 먼저 생성되도록 (앱은 기본 wave 0)
+    argocd.argoproj.io/sync-wave: "-1"
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/DGU-CAP/infra.git
+    targetRevision: HEAD
+    path: k8s/manifests/overlays/eks/secretstore
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: external-secrets
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true

--- a/k8s/manifests/overlays/eks/ai/externalsecret.yaml
+++ b/k8s/manifests/overlays/eks/ai/externalsecret.yaml
@@ -1,0 +1,16 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: ai-secret
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: aws-secretsmanager
+    kind: ClusterSecretStore
+  target:
+    name: ai-secret # deployment의 secretRef와 일치
+    creationPolicy: Owner
+  dataFrom:
+    # Secrets Manager의 dgu-cap/ai (JSON, OPENAI_API_KEY 등)의 모든 키를 추출
+    - extract:
+        key: dgu-cap/ai

--- a/k8s/manifests/overlays/eks/ai/kustomization.yaml
+++ b/k8s/manifests/overlays/eks/ai/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 
 resources:
   - ../../../base/ai
+  - externalsecret.yaml
 
 patches:
   - path: patch.yaml

--- a/k8s/manifests/overlays/eks/backend/externalsecret.yaml
+++ b/k8s/manifests/overlays/eks/backend/externalsecret.yaml
@@ -1,0 +1,16 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: backend-secret
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: aws-secretsmanager
+    kind: ClusterSecretStore
+  target:
+    name: backend-secret # deployment의 secretRef와 일치
+    creationPolicy: Owner
+  dataFrom:
+    # Secrets Manager의 dgu-cap/backend (JSON)의 모든 키를 Secret으로 추출
+    - extract:
+        key: dgu-cap/backend

--- a/k8s/manifests/overlays/eks/backend/kustomization.yaml
+++ b/k8s/manifests/overlays/eks/backend/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 
 resources:
   - ../../../base/backend
+  - externalsecret.yaml
 
 patches:
   - path: patch.yaml

--- a/k8s/manifests/overlays/eks/secretstore/clustersecretstore.yaml
+++ b/k8s/manifests/overlays/eks/secretstore/clustersecretstore.yaml
@@ -1,0 +1,15 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ClusterSecretStore
+metadata:
+  name: aws-secretsmanager
+spec:
+  provider:
+    aws:
+      service: SecretsManager
+      region: ap-northeast-2
+      auth:
+        # ESO 컨트롤러 SA의 IRSA(role-arn 어노테이션)로 인증
+        jwt:
+          serviceAccountRef:
+            name: external-secrets
+            namespace: external-secrets

--- a/k8s/manifests/overlays/eks/secretstore/kustomization.yaml
+++ b/k8s/manifests/overlays/eks/secretstore/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - clustersecretstore.yaml

--- a/terraform/external-secrets.tf
+++ b/terraform/external-secrets.tf
@@ -1,0 +1,111 @@
+# ──────────────────────────────────────────
+# External Secrets Operator (ESO) + AWS Secrets Manager
+# K8s Secret을 git에 두지 않고 Secrets Manager에서 주입 (IRSA 기반)
+# ──────────────────────────────────────────
+
+data "aws_caller_identity" "current" {}
+
+# ──────────────────────────────────────────
+# ESO IRSA 역할 (external-secrets 컨트롤러 SA가 빌림)
+# ──────────────────────────────────────────
+data "aws_iam_policy_document" "external_secrets_assume_role" {
+  statement {
+    effect = "Allow"
+
+    principals {
+      type        = "Federated"
+      identifiers = [aws_iam_openid_connect_provider.eks.arn]
+    }
+
+    actions = ["sts:AssumeRoleWithWebIdentity"]
+
+    condition {
+      test     = "StringEquals"
+      variable = "${local.oidc_provider}:aud"
+      values   = ["sts.amazonaws.com"]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "${local.oidc_provider}:sub"
+      values   = ["system:serviceaccount:external-secrets:external-secrets"]
+    }
+  }
+}
+
+resource "aws_iam_role" "external_secrets" {
+  name               = "${var.project_name}-external-secrets-role"
+  assume_role_policy = data.aws_iam_policy_document.external_secrets_assume_role.json
+
+  tags = {
+    Name        = "${var.project_name}-external-secrets-role"
+    Environment = var.environment
+  }
+}
+
+# 최소권한: dgu-cap/* 프리픽스 시크릿만 읽기
+data "aws_iam_policy_document" "external_secrets" {
+  statement {
+    effect = "Allow"
+    actions = [
+      "secretsmanager:GetSecretValue",
+      "secretsmanager:DescribeSecret",
+      "secretsmanager:ListSecretVersionIds",
+    ]
+    resources = [
+      "arn:aws:secretsmanager:${var.aws_region}:${data.aws_caller_identity.current.account_id}:secret:${var.project_name}/*",
+    ]
+  }
+}
+
+resource "aws_iam_policy" "external_secrets" {
+  name        = "${var.project_name}-external-secrets-policy"
+  description = "External Secrets Operator가 ${var.project_name}/* 시크릿을 읽기 위한 정책"
+  policy      = data.aws_iam_policy_document.external_secrets.json
+
+  tags = {
+    Name        = "${var.project_name}-external-secrets-policy"
+    Environment = var.environment
+  }
+}
+
+resource "aws_iam_role_policy_attachment" "external_secrets" {
+  role       = aws_iam_role.external_secrets.name
+  policy_arn = aws_iam_policy.external_secrets.arn
+}
+
+# ──────────────────────────────────────────
+# External Secrets Operator (Helm)
+# ──────────────────────────────────────────
+resource "helm_release" "external_secrets" {
+  name             = "external-secrets"
+  repository       = "https://charts.external-secrets.io"
+  chart            = "external-secrets"
+  version          = "0.10.7" # 차트 버전 고정 (재현성)
+  namespace        = "external-secrets"
+  create_namespace = true
+
+  wait = true
+
+  set {
+    name  = "installCRDs"
+    value = "true"
+  }
+
+  # 컨트롤러 SA에 IRSA 역할 ARN 주입 (SecretStore가 이 SA로 인증)
+  set {
+    name  = "serviceAccount.annotations.eks\\.amazonaws\\.com/role-arn"
+    value = aws_iam_role.external_secrets.arn
+  }
+
+  depends_on = [
+    aws_eks_node_group.main,
+    aws_iam_role_policy_attachment.external_secrets,
+    aws_iam_openid_connect_provider.eks,
+  ]
+}
+
+output "external_secrets_role_arn" {
+  description = "External Secrets Operator IRSA 역할 ARN"
+  value       = aws_iam_role.external_secrets.arn
+}


### PR DESCRIPTION
closes #55

## 개요
K8s 시크릿(`backend-secret`, `ai-secret`)을 **External Secrets Operator(ESO) + AWS Secrets Manager**로 GitOps화한다. 비밀값은 git에 남지 않고 Secrets Manager에만 보관, ESO는 IRSA로 읽기 권한만 갖는다. (기존: 평문 secret.yaml은 gitignore되어 ArgoCD가 시크릿을 못 만들어 Pod 기동 실패하던 문제 해결)

## 변경
### terraform
- `external-secrets.tf` 신규
  - ESO용 **IRSA 역할** — `secretsmanager:GetSecretValue/DescribeSecret/ListSecretVersionIds`를 `dgu-cap/*`로 최소권한 스코프
  - **External Secrets Operator** Helm 설치 (차트 `0.10.7` 고정, `installCRDs`, 컨트롤러 SA에 role-arn 주입)

### k8s (eks overlay 전용)
- `overlays/eks/secretstore/` — `ClusterSecretStore`(aws-secretsmanager), IRSA SA(jwt)로 인증
- `overlays/eks/backend/externalsecret.yaml`, `overlays/eks/ai/externalsecret.yaml` — `dgu-cap/backend`, `dgu-cap/ai`에서 `dataFrom.extract`로 추출 → `backend-secret`/`ai-secret` 생성
- 각 overlay `kustomization.yaml`에 ExternalSecret 추가
- `apps/secretstore.yaml` — ClusterSecretStore용 ArgoCD App (`sync-wave: -1`로 ExternalSecret보다 선행)

### 문서
- `README.md` — ESO 운영 가이드 추가, Secrets Manager 등록 예시, 기존 SealedSecrets는 (구) 표기

## 배포 후 운영자 작업 (필수)
ESO는 시크릿을 *읽기만* 한다. 값 등록은 직접:
```bash
aws secretsmanager create-secret --name dgu-cap/backend \
  --secret-string '{"SPRING_DATASOURCE_PASSWORD":"...","JWT_SECRET":"..."}'
aws secretsmanager create-secret --name dgu-cap/ai \
  --secret-string '{"OPENAI_API_KEY":"sk-..."}'
```
키 이름이 그대로 Pod 환경변수가 된다. 회전은 `put-secret-value` → ESO가 1h 내 자동 반영.

## 비고 / 범위
- **로컬(kind)** 은 Secrets Manager 미접근 → 기존 수동 `kubectl create secret` 유지(ExternalSecret은 eks overlay에만).
- 기존 `sealed-secrets` 설치는 본 PR에서 제거하지 않음(후속 정리).
- `terraform fmt` 통과, 매니페스트 YAML 검증 완료. (로컬에 kustomize/kubectl 없어 `kustomize build` 실검증은 클러스터 환경에서 권장)

🤖 Generated with [Claude Code](https://claude.com/claude-code)