### PR TITLE
fix: 코드리뷰 critical/high 항목 수정 (#57)

### DIFF
--- a/k8s/manifests/base/ai/deployment.yaml
+++ b/k8s/manifests/base/ai/deployment.yaml
@@ -20,6 +20,13 @@ spec:
                 name: ai-secret
           ports:
             - containerPort: 8000
+          resources:
+            requests:
+              cpu: 250m
+              memory: 512Mi
+            limits:
+              cpu: 500m
+              memory: 1Gi
           volumeMounts:
             - name: model-storage
               mountPath: /code/models

--- a/k8s/manifests/base/ai/pvc.yaml
+++ b/k8s/manifests/base/ai/pvc.yaml
@@ -7,4 +7,4 @@ spec:
     - ReadWriteOnce
   resources:
     requests:
-      storage: 100Mi
+      storage: 10Gi

--- a/k8s/manifests/base/backend/configmap.yaml
+++ b/k8s/manifests/base/backend/configmap.yaml
@@ -8,7 +8,7 @@ data:
   SPRING_DATA_REDIS_HOST: redis
   SPRING_DATA_REDIS_PORT: "6379"
   PROMETHEUS_URL: http://kube-prometheus-stack-prometheus.monitoring:9090
-  LOKI_URL: http://loki-gateway.monitoring:80
+  LOKI_URL: http://loki.monitoring.svc:3100
   AI_URL: http://ai:8000
   ANOMALY_THRESHOLD_CPU: "90.0"
   ANOMALY_THRESHOLD_MEMORY: "85.0"

--- a/k8s/manifests/base/backend/deployment.yaml
+++ b/k8s/manifests/base/backend/deployment.yaml
@@ -23,3 +23,10 @@ spec:
                 name: backend-config
             - secretRef:
                 name: backend-secret
+          resources:
+            requests:
+              cpu: 250m
+              memory: 512Mi
+            limits:
+              cpu: 500m
+              memory: 768Mi

--- a/k8s/manifests/base/frontend/deployment.yaml
+++ b/k8s/manifests/base/frontend/deployment.yaml
@@ -17,3 +17,10 @@ spec:
           image: 428185450315.dkr.ecr.ap-northeast-2.amazonaws.com/dgu-cap-frontend:latest
           ports:
             - containerPort: 3000
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              cpu: 100m
+              memory: 128Mi

--- a/k8s/manifests/base/postgres/kustomization.yaml
+++ b/k8s/manifests/base/postgres/kustomization.yaml
@@ -2,5 +2,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-  - deployment.yaml
+  - statefulset.yaml
   - service.yaml

--- a/k8s/manifests/base/postgres/statefulset.yaml
+++ b/k8s/manifests/base/postgres/statefulset.yaml
@@ -1,8 +1,9 @@
 apiVersion: apps/v1
-kind: Deployment
+kind: StatefulSet
 metadata:
   name: postgres
 spec:
+  serviceName: postgres
   replicas: 1
   selector:
     matchLabels:
@@ -24,6 +25,12 @@ spec:
               value: dgu_cap
             - name: POSTGRES_PASSWORD
               value: dgu_cap_local
+            # PGDATA를 마운트 볼륨의 하위 경로로 지정 (lost+found 충돌 회피)
+            - name: PGDATA
+              value: /var/lib/postgresql/data/pgdata
+          volumeMounts:
+            - name: data
+              mountPath: /var/lib/postgresql/data
           resources:
             requests:
               cpu: 100m
@@ -31,3 +38,13 @@ spec:
             limits:
               cpu: 200m
               memory: 256Mi
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        # storageClassName 생략 → 클러스터 기본 SC 사용 (kind=standard / EKS=gp3)
+        resources:
+          requests:
+            storage: 10Gi


### PR DESCRIPTION
closes #57

## 변경
- **postgres**: `Deployment` → `StatefulSet` + `volumeClaimTemplates`(10Gi, 기본 SC) — Pod 재시작/노드 교체 시 데이터 전손실 해결. PGDATA를 subPath로 분리(lost+found 충돌 회피)
- **backend configmap**: `LOKI_URL` `loki-gateway.monitoring:80`(비활성) → `loki.monitoring.svc:3100`
- **backend/ai/frontend**: resources requests·limits 추가 (t3.small OOM/eviction 방지)
- **ai**: 모델 PVC `100Mi` → `10Gi`

base만 수정해 eks/kind overlay 양쪽 자동 반영. YAML 검증 통과.

🤖 Generated with [Claude Code](https://claude.com/claude-code)