### PR TITLE
feat: 워크로드 securityContext 추가 (컨테이너 하드닝) (#61)

### DIFF
--- a/k8s/manifests/base/ai/statefulset.yaml
+++ b/k8s/manifests/base/ai/statefulset.yaml
@@ -13,9 +13,17 @@ spec:
       labels:
         app: ai
     spec:
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       containers:
         - name: ai
           image: 428185450315.dkr.ecr.ap-northeast-2.amazonaws.com/dgu-cap-ai:latest
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
           envFrom:
             - secretRef:
                 name: ai-secret

--- a/k8s/manifests/base/backend/deployment.yaml
+++ b/k8s/manifests/base/backend/deployment.yaml
@@ -13,11 +13,19 @@ spec:
         app: backend
     spec:
       serviceAccountName: backend
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       containers:
         - name: backend
           image: 428185450315.dkr.ecr.ap-northeast-2.amazonaws.com/dgu-cap-backend:latest
           ports:
             - containerPort: 8080
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
           envFrom:
             - configMapRef:
                 name: backend-config

--- a/k8s/manifests/base/frontend/deployment.yaml
+++ b/k8s/manifests/base/frontend/deployment.yaml
@@ -12,11 +12,19 @@ spec:
       labels:
         app: frontend
     spec:
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       containers:
         - name: frontend
           image: 428185450315.dkr.ecr.ap-northeast-2.amazonaws.com/dgu-cap-frontend:latest
           ports:
             - containerPort: 3000
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
           resources:
             requests:
               cpu: 50m

--- a/k8s/manifests/base/postgres/statefulset.yaml
+++ b/k8s/manifests/base/postgres/statefulset.yaml
@@ -13,9 +13,16 @@ spec:
       labels:
         app: postgres
     spec:
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       containers:
         - name: postgres
           image: postgres:16-alpine
+          # postgres 공식 이미지는 root로 시작해 postgres 유저로 권한 드롭(캡 필요)
+          # → drop ALL/runAsNonRoot 미적용. no_new_privs만 안전하게 설정.
+          securityContext:
+            allowPrivilegeEscalation: false
           ports:
             - containerPort: 5432
           env:

--- a/k8s/manifests/base/redis/deployment.yaml
+++ b/k8s/manifests/base/redis/deployment.yaml
@@ -12,11 +12,19 @@ spec:
       labels:
         app: redis
     spec:
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       containers:
         - name: redis
           image: redis:7-alpine
           ports:
             - containerPort: 6379
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
           resources:
             requests:
               cpu: 50m


### PR DESCRIPTION
closes #61

## 개요
모든 워크로드에 securityContext가 없던 문제(코드리뷰 #7)를 **이미지 깨짐 위험이 없는 안전 부분집합**으로 하드닝.

## 적용
| 워크로드 | pod-level | container-level |
|---|---|---|
| backend / ai / frontend / redis | `seccompProfile: RuntimeDefault` | `allowPrivilegeEscalation: false` + `capabilities.drop: [ALL]` |
| postgres | `seccompProfile: RuntimeDefault` | `allowPrivilegeEscalation: false` (drop ALL 제외) |

- 앱/redis는 포트 >1024라 `NET_BIND_SERVICE` 등 캡 불필요 → `drop [ALL]` 안전.
- **postgres**는 공식 이미지가 root로 시작해 `postgres` 유저로 권한 드롭(CHOWN/SETUID 등 캡 필요) → `drop ALL`/`runAsNonRoot` 적용 시 initdb 실패하므로 제외, `no_new_privs`만 설정.

## 의도적으로 제외 (후속, 이미지 검증 필요)
- `runAsNonRoot: true` / `runAsUser` — 각 ECR 이미지가 non-root 사용자를 지원하는지 Dockerfile 확인 후
- `readOnlyRootFilesystem: true` — 앱이 쓰는 임시경로에 emptyDir 마운트 필요

base 적용 → kind/eks overlay 공통 상속. YAML 검증 완료.

🤖 Generated with [Claude Code](https://claude.com/claude-code)