### PR TITLE
chore: ECR MUTABLE → IMMUTABLE (#63)

### DIFF
--- a/terraform/ecr.tf
+++ b/terraform/ecr.tf
@@ -10,7 +10,7 @@ resource "aws_ecr_repository" "apps" {
   for_each = toset(local.ecr_repos)
 
   name                 = "${var.project_name}-${each.key}"
-  image_tag_mutability = "MUTABLE"
+  image_tag_mutability = "IMMUTABLE" # 태그 덮어쓰기 금지 (커밋 SHA 태그 전제)
 
   image_scanning_configuration {
     scan_on_push = true


### PR DESCRIPTION
closes #63

## 변경
- `terraform/ecr.tf`: `image_tag_mutability = "IMMUTABLE"` (backend/frontend/ai 3개 레포 공통, for_each)

동일 태그에 다른 이미지를 덮어쓰지 못하게 해 배포 이미지 추적성·공급망 안전성 확보. (코드리뷰 #19/#24)

## ⚠️ 운영 주의 — :latest 전환 필요
IMMUTABLE은 **이미 존재하는 태그로 push하면 거부**한다.
- 현재 deployment들이 `:latest`를 사용 → CI가 `:latest`를 두 번째로 push하면 **실패**한다.
- 따라서 실제 적용 전에 **`:latest` → 커밋 SHA 태그 전환**(CI push + kustomize `images:`)이 동반되어야 한다. (별도 작업)
- 기존에 이미 push된 `:latest` 이미지가 있으면 `terraform apply` 시 레포 설정만 바뀌고 기존 이미지는 유지되나, 이후 같은 태그 push가 막힘.

## 검증
- `terraform fmt` 통과. (적용은 EKS/AWS 환경에서 `terraform plan`으로 확인 권장 — 기존 레포의 mutability 변경은 in-place 업데이트)

🤖 Generated with [Claude Code](https://claude.com/claude-code)