### PR TITLE
fix: redis runAsUser/runAsGroup 999 설정 (closes #67)

### DIFF
--- a/k8s/manifests/base/redis/deployment.yaml
+++ b/k8s/manifests/base/redis/deployment.yaml
@@ -25,6 +25,8 @@ spec:
             capabilities:
               drop:
                 - ALL
+            runAsUser: 999
+            runAsGroup: 999
           resources:
             requests:
               cpu: 50m


### PR DESCRIPTION
## 관련 이슈
closes #67

## 변경 사항
- `k8s/manifests/base/redis/deployment.yaml` 컨테이너 securityContext에 `runAsUser: 999`, `runAsGroup: 999` 추가

## 작업 내용 상세
redis:7-alpine 이미지는 기본적으로 root(UID 0)로 프로세스를 시작함.
`capabilities: drop: ALL` 설정 하에서 root로 실행하면 필요한 권한이 차단되어 파드가 정상 기동되지 않음.
redis 공식 이미지에 미리 생성된 `redis` 유저(UID/GID 999)로 실행하도록 명시하여 최소 권한 원칙을 준수함.

## 체크리스트
- [ ] `terraform plan` 실행하여 의도한 변경만 포함되어 있음을 확인
- [ ] 리소스 태그 (Name, Environment) 누락 없음
- [ ] 민감 정보 (access key 등) 코드에 포함되지 않음