### PR TITLE
chore: EKS 노드그룹 t3.medium 3대로 변경 (closes #69)

### DIFF
--- a/terraform/eks-nodegroup.tf
+++ b/terraform/eks-nodegroup.tf
@@ -6,14 +6,14 @@ resource "aws_eks_node_group" "main" {
   # 각 AZ의 Private Subnet에 노드 분산 배치
   subnet_ids = aws_subnet.private[*].id
 
-  instance_types = ["t3.small"]
+  instance_types = ["t3.medium"]
   ami_type       = "AL2023_x86_64_STANDARD"
   capacity_type  = "ON_DEMAND"
 
   scaling_config {
-    desired_size = 4
+    desired_size = 3
     min_size     = 2
-    max_size     = 4
+    max_size     = 3
   }
 
   update_config {


### PR DESCRIPTION
## 관련 이슈
closes #69

## 변경 사항
- `instance_types`: `t3.small` → `t3.medium`
- `scaling_config`: desired 4 → 3, max 4 → 3

## 작업 내용 상세
파드 메모리 부족 문제 해결을 위한 노드 사양 변경.
t3.small(2 GiB) × 4대 구성에서는 kube-system 데몬 + 전체 워크로드(prometheus, loki, redis, postgres, backend, ai)를 수용하기에 메모리가 부족함.
t3.medium(4 GiB) × 3대로 변경 시 총 메모리가 8 GiB → 12 GiB로 증가하여 파드 스케줄링 여유 확보.

| 구분 | 현재 | 변경 후 |
|---|---|---|
| 인스턴스 | t3.small × 4 | t3.medium × 3 |
| 총 CPU | 8 vCPU | 6 vCPU |
| 총 RAM | 8 GiB | 12 GiB |

## 체크리스트
- [ ] `terraform plan` 실행하여 의도한 변경만 포함되어 있음을 확인
- [ ] 리소스 태그 (Name, Environment) 누락 없음
- [ ] 민감 정보 (access key 등) 코드에 포함되지 않음