### PR TITLE
chore: EKS 노드그룹 5대로 증설 (closes #73)

### DIFF
--- a/terraform/eks-nodegroup.tf
+++ b/terraform/eks-nodegroup.tf
@@ -11,9 +11,9 @@ resource "aws_eks_node_group" "main" {
   capacity_type  = "ON_DEMAND"
 
   scaling_config {
-    desired_size = 3
+    desired_size = 5
     min_size     = 2
-    max_size     = 3
+    max_size     = 5
   }
 
   update_config {


### PR DESCRIPTION
## 관련 이슈
closes #73

## 변경 사항
- `terraform/eks-nodegroup.tf` scaling_config desired_size 3 → 5, max_size 3 → 5

## 작업 내용 상세
Online Boutique(12 pods) + monitoring + argocd + system 파드 합산 시 t3.medium 3대 한계(노드당 17개 × 3 = 51개) 도달.
node-exporter, promtail DaemonSet이 Pending 상태가 되어 특정 노드 모니터링 공백 발생.
5대로 증설하여 전 노드 커버리지 확보. `terraform apply`는 이미 적용 완료.

| 구분 | 변경 전 | 변경 후 |
|---|---|---|
| 노드 수 | 3대 | 5대 |
| 파드 수용량 | ~51개 | ~85개 |

## 체크리스트
- [x] `terraform plan` 실행하여 의도한 변경만 포함되어 있음을 확인
- [x] `terraform apply` 적용 완료 (노드 5대 Ready 확인)
- [ ] 리소스 태그 (Name, Environment) 누락 없음
- [ ] 민감 정보 (access key 등) 코드에 포함되지 않음